### PR TITLE
Add Cluster Name Sentry Tag to Logs

### DIFF
--- a/index.js
+++ b/index.js
@@ -40,7 +40,10 @@ function logging(config) {
     const sentryOptions = {
       dsn: config.SENTRY_DSN,
       environment: config.NODE_ENV,
-      level: "error"
+      level: "error",
+      tags: {
+        clusterName: config.CLUSTER_NAME
+      }
     };
     let logger = new winston.Logger();
     logger.add(Sentry, sentryOptions);
@@ -106,7 +109,8 @@ function logging(config) {
     config = {
       SENTRY_DSN: config.SENTRY_DSN || process.env.SENTRY_DSN,
       NODE_ENV: config.NODE_ENV || process.env.NODE_ENV,
-      DISABLE_LOGS: config.DISABLE_LOGS || process.env.DISABLE_LOGS === "true"
+      DISABLE_LOGS: config.DISABLE_LOGS || process.env.DISABLE_LOGS === "true",
+      CLUSTER_NAME: config.CLUSTER_NAME || process.env.CLUSTER_NAME
     };
   }
 


### PR DESCRIPTION
Platform would like to add cluster name tags to sentry errors. This PR will add that tag to to any service using this logger if either `CLUSTER_NAME` is an environment variable, or if `CLUSTER_NAME` is specified in the logger config object.