### PR TITLE
make the fallthrough configurable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,4 +58,5 @@ typings/
 .env
 
 .idea/
+.vscode/
 coverage/

--- a/README.md
+++ b/README.md
@@ -10,7 +10,10 @@ Module for logging from express js based services
 const loggerConfig = {
                            SENTRY_DSN: process.env.SENTRY_DSN,
                            NODE_ENV: process.env.NODE_ENV,
-                           DISABLE_LOGS: process.env.DISABLE_LOGS === "true"
+                           DISABLE_LOGS: process.env.DISABLE_LOGS === "true",
+                           handleFallThroughErrors: function(app) {
+                             return {}
+                           }
                       };
 
 const logger = require("logger")(loggerConfig);
@@ -39,3 +42,36 @@ SENTRY_DSN
 NODE_ENV
 DISABLE_LOGS
 ```
+
+## Custom Error Fallback
+If you would like to define the custom fall through error, set it in the config and pass in the app.
+Example:
+``` javascript
+const loggerConfig = {
+  handleFallThroughErrors: function(app) {
+    app.use(function (err, req, res, next) {
+      // This set the statusCode correctly for uncaught exceptions, no exceptions. ;)
+      // this handles situations where res.statusCode is undefined because of an a code exception.
+      let statusCode = res.statusCode > 200 ? res.statusCode : 500;
+
+     if (typeof err !== 'object') {
+        err = {
+          message: String(err)
+        };
+      } else {
+        Object.defineProperty(err, 'message', { enumberable: true });
+      }
+
+      res.set('Content-Type', 'application/json');
+      res.statusCode = statusCode;
+      res.end(JSON.stringify({
+        errors: err.results ? err.results.errors : err.message,
+        statusCode: statusCode,
+        message: err.code
+      }));
+    })
+  }
+
+}
+```
+If this is not defined a default fallthrough is used.


### PR DESCRIPTION
* Configure the Fallthrough

I have modified this library to allow someone to customize the "next" or fallthrough error handling.

This is useful in some scenarios where we don't want this library to terminate the response.